### PR TITLE
change `create*` function signature to accept partial type

### DIFF
--- a/.changeset/great-schools-rhyme.md
+++ b/.changeset/great-schools-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@guardian/google-admanager-api": minor
+---
+
+Change `create*` function parameter types to be partials of their corresponding types

--- a/lib/client/services/activity/activity.service.ts
+++ b/lib/client/services/activity/activity.service.ts
@@ -10,7 +10,7 @@ export class ActivityService implements ActivityServiceOperations {
     this._client = client;
   }
 
-  async createActivities(activities: Activity[]): Promise<Activity[]> {
+  async createActivities(activities: Partial<Activity>[]): Promise<Activity[]> {
     return this._client.createActivities({ activities });
   }
 

--- a/lib/client/services/activity/activityService.interface.ts
+++ b/lib/client/services/activity/activityService.interface.ts
@@ -16,7 +16,7 @@ export interface ActivityServiceOperations {
    * @param activities the activity to be created.
    * @returns the created activities with its IDs filled in.
    */
-  createActivities(activities: Activity[]): Promise<Activity[]>;
+  createActivities(activities: Partial<Activity>[]): Promise<Activity[]>;
   /**
    * Gets an {@link https://developers.google.com/ad-manager/api/reference/v202405/ActivityService.ActivityPage ActivityPage}
    * of {@link https://developers.google.com/ad-manager/api/reference/v202405/ActivityService.Activity Activity} objects that satisfy the given

--- a/lib/client/services/adRule/adRule.service.ts
+++ b/lib/client/services/adRule/adRule.service.ts
@@ -17,11 +17,11 @@ export class AdRuleService implements AdRuleServiceOperations {
     this._client = client;
   }
 
-  createAdRules(adRules: AdRule[]): Promise<AdRule[]> {
+  createAdRules(adRules: Partial<AdRule>[]): Promise<AdRule[]> {
     return this._client.createAdRules({ adRules });
   }
 
-  createAdSpots(adSports: AdSpot[]): Promise<AdSpot[]> {
+  createAdSpots(adSports: Partial<AdSpot>[]): Promise<AdSpot[]> {
     return this._client.createAdSpots({ adSports });
   }
 

--- a/lib/client/services/adRule/adRuleService.interface.ts
+++ b/lib/client/services/adRule/adRuleService.interface.ts
@@ -20,7 +20,7 @@ export interface AdRuleServiceOperations {
    * @param adRules the ad rules to create
    * @returns the created ad rules with their IDs filled in
    */
-  createAdRules(adRules: AdRule[]): Promise<AdRule[]>;
+  createAdRules(adRules: Partial<AdRule>[]): Promise<AdRule[]>;
 
   /**
    * Creates new AdSpot objects.
@@ -28,7 +28,7 @@ export interface AdRuleServiceOperations {
    * @param adSports the ad spots to create
    * @returns the created ad spots with their IDs filled in
    */
-  createAdSpots(adSports: AdSpot[]): Promise<AdSpot[]>;
+  createAdSpots(adSports: Partial<AdSpot>[]): Promise<AdSpot[]>;
 
   /**
    * Creates new breakTemplate objects.

--- a/lib/client/services/company/company.service.ts
+++ b/lib/client/services/company/company.service.ts
@@ -11,7 +11,7 @@ export class CompanyService implements CompanyServiceOperations {
     this._client = client;
   }
 
-  async createCompanies(companies: Company[]): Promise<Company[]> {
+  async createCompanies(companies: Partial<Company>[]): Promise<Company[]> {
     return this._client.createCompanies({ companies });
   }
 

--- a/lib/client/services/company/companyService.interface.ts
+++ b/lib/client/services/company/companyService.interface.ts
@@ -12,7 +12,7 @@ export interface CompanyServiceOperations {
    * @param companies the companies to create
    * @returns the created companies with their IDs filled in
    */
-  createCompanies(companies: Company[]): Promise<Company[]>;
+  createCompanies(companies: Partial<Company>[]): Promise<Company[]>;
   /**
    * Gets a {@link https://developers.google.com/ad-manager/api/reference/v202405/CompanyService.CompanyPage CompanyPage}
    * of {@link https://developers.google.com/ad-manager/api/reference/v202405/CompanyService.Company Company} objects that satisfy the given

--- a/lib/client/services/contact/contact.service.ts
+++ b/lib/client/services/contact/contact.service.ts
@@ -10,7 +10,7 @@ export class ContactService implements ContactServiceOperations {
     this._client = client;
   }
 
-  async createContacts(contacts: Contact[]): Promise<Contact[]> {
+  async createContacts(contacts: Partial<Contact>[]): Promise<Contact[]> {
     return this._client.createContacts({ contacts });
   }
 

--- a/lib/client/services/contact/contactService.interface.ts
+++ b/lib/client/services/contact/contactService.interface.ts
@@ -11,7 +11,7 @@ export interface ContactServiceOperations {
    * @param contacts the contacts to create
    * @returns the created contacts with their IDs filled in
    */
-  createContacts(contacts: Contact[]): Promise<Contact[]>;
+  createContacts(contacts: Partial<Contact>[]): Promise<Contact[]>;
   /**
    * Gets a {@link https://developers.google.com/ad-manager/api/reference/v202405/ContactService.ContactPage ContactPage}
    * of {@link https://developers.google.com/ad-manager/api/reference/v202405/ContactService.Contact Contact} objects that satisfy the given

--- a/lib/client/services/creative/creative.service.ts
+++ b/lib/client/services/creative/creative.service.ts
@@ -11,7 +11,7 @@ export class CreativeService implements CreativeServiceOperations {
     this._client = client;
   }
 
-  async createCreatives(creatives: Creative[]): Promise<Creative[]> {
+  async createCreatives(creatives: Partial<Creative>[]): Promise<Creative[]> {
     return this._client.createCreatives({ creatives });
   }
 

--- a/lib/client/services/creative/creativeService.interface.ts
+++ b/lib/client/services/creative/creativeService.interface.ts
@@ -15,7 +15,7 @@ export interface CreativeServiceOperations {
    * @param creatives the creatives to create
    * @returns the created creatives with their IDs filled in
    */
-  createCreatives(creatives: Creative[]): Promise<Creative[]>;
+  createCreatives(creatives: Partial<Creative>[]): Promise<Creative[]>;
   /**
    * Gets a {@link https://developers.google.com/ad-manager/api/reference/v202405/CreativeService.CreativePage CreativePage}
    * of {@link https://developers.google.com/ad-manager/api/reference/v202405/CreativeService.Creative Creative} objects that satisfy the given

--- a/lib/client/services/creativeSet/creativeSet.service.ts
+++ b/lib/client/services/creativeSet/creativeSet.service.ts
@@ -10,7 +10,9 @@ export class CreativeSetService implements CreativeSetServiceOperations {
     this._client = client;
   }
 
-  async createCreativeSet(creativeSet: CreativeSet): Promise<CreativeSet> {
+  async createCreativeSet(
+    creativeSet: Partial<CreativeSet>,
+  ): Promise<CreativeSet> {
     return this._client.createCreativeSet({ creativeSet });
   }
 

--- a/lib/client/services/creativeSet/creativeSetService.interface.ts
+++ b/lib/client/services/creativeSet/creativeSetService.interface.ts
@@ -11,7 +11,7 @@ export interface CreativeSetServiceOperations {
    * @param creativeSet the creative set to create
    * @returns the created creative set with their IDs filled in
    */
-  createCreativeSet(creativeSet: CreativeSet): Promise<CreativeSet>;
+  createCreativeSet(creativeSet: Partial<CreativeSet>): Promise<CreativeSet>;
   /**
    * Gets a {@link https://developers.google.com/ad-manager/api/reference/v202405/CreativeSetService.CreativeSetPage CreativeSetPage}
    * of {@link https://developers.google.com/ad-manager/api/reference/v202405/CreativeSetService.CreativeSet CreativeSet} objects that satisfy the given

--- a/lib/client/services/customField/customFieldService.interface.ts
+++ b/lib/client/services/customField/customFieldService.interface.ts
@@ -38,7 +38,9 @@ export interface CustomFieldServiceOperations {
    * @param customFields the custom fields to create
    * @returns the created custom fields with their IDs filled in
    */
-  createCustomFields(customFields: CustomField[]): Promise<CustomField[]>;
+  createCustomFields(
+    customFields: Partial<CustomField>[],
+  ): Promise<CustomField[]>;
   /**
    * Returns the {@link https://developers.google.com/ad-manager/api/reference/v202405/CustomFieldService.CustomFieldOption CustomFieldOption}
    * uniquely identified by the given ID.

--- a/lib/client/services/inventory/inventory.service.ts
+++ b/lib/client/services/inventory/inventory.service.ts
@@ -11,7 +11,7 @@ export class InventoryService implements InventoryServiceOperations {
     this._client = client;
   }
 
-  async createAdUnits(adUnits: AdUnit[]): Promise<AdUnit[]> {
+  async createAdUnits(adUnits: Partial<AdUnit>[]): Promise<AdUnit[]> {
     return this._client.createAdUnits({ adUnits });
   }
 

--- a/lib/client/services/inventory/inventoryService.interface.ts
+++ b/lib/client/services/inventory/inventoryService.interface.ts
@@ -19,7 +19,7 @@ export interface InventoryServiceOperations {
    * @param adUnits the ad units to create
    * @returns the created ad units, with their IDs filled in
    */
-  createAdUnits(adUnits: AdUnit[]): Promise<AdUnit[]>;
+  createAdUnits(adUnits: Partial<AdUnit>[]): Promise<AdUnit[]>;
   /**
    * Returns a set of all relevant {@link https://developers.google.com/ad-manager/api/reference/v202405/InventoryService.AdUnitSize AdUnitSize} objects.
    *

--- a/lib/client/services/label/label.interface.ts
+++ b/lib/client/services/label/label.interface.ts
@@ -12,7 +12,7 @@ export interface LabelServiceOperations {
    * @param labels the labels to create
    * @returns the created labels with their IDs filled in
    */
-  createLabels(labels: Label[]): Promise<Label[]>;
+  createLabels(labels: Partial<Label>[]): Promise<Label[]>;
   /**
    * Gets a {@link https://developers.google.com/ad-manager/api/reference/v202405/LabelService.LabelPage LabelPage}
    * of {@link https://developers.google.com/ad-manager/api/reference/v202405/LabelService.Label Label} objects that satisfy the given

--- a/lib/client/services/label/label.service.ts
+++ b/lib/client/services/label/label.service.ts
@@ -11,7 +11,7 @@ export class LabelService implements LabelServiceOperations {
     this._client = client;
   }
 
-  async createLabels(labels: Label[]): Promise<Label[]> {
+  async createLabels(labels: Partial<Label>[]): Promise<Label[]> {
     return this._client.createLabels({ labels });
   }
 

--- a/lib/client/services/lineItem/lineItem.service.ts
+++ b/lib/client/services/lineItem/lineItem.service.ts
@@ -11,7 +11,7 @@ export class LineItemService implements LineItemServiceOperations {
     this._client = client;
   }
 
-  async createLineItems(lineItems: LineItem[]): Promise<LineItem[]> {
+  async createLineItems(lineItems: Partial<LineItem>[]): Promise<LineItem[]> {
     return this._client.createLineItems({ lineItems });
   }
 

--- a/lib/client/services/lineItem/lineItemService.interface.ts
+++ b/lib/client/services/lineItem/lineItemService.interface.ts
@@ -24,7 +24,7 @@ export interface LineItemServiceOperations {
    * @param lineItems the line items to create
    * @returns the created line items with their IDs filled in
    */
-  createLineItems(lineItems: LineItem[]): Promise<LineItem[]>;
+  createLineItems(lineItems: Partial<LineItem>[]): Promise<LineItem[]>;
   /**
    * Gets a {@link https://developers.google.com/ad-manager/api/reference/v202405/LineItemService.LineItemPage LineItemPage}
    * of {@link https://developers.google.com/ad-manager/api/reference/v202405/LineItemService.LineItem LineItem} objects that satisfy the given

--- a/lib/client/services/liveStreamEvent/liveStreamEvent.service.ts
+++ b/lib/client/services/liveStreamEvent/liveStreamEvent.service.ts
@@ -24,7 +24,7 @@ export class LiveStreamEventService
     return this._client.createLiveStreamEvents({ liveStreamEvents });
   }
 
-  createSlates(slates: Slate[]): Promise<Slate[]> {
+  createSlates(slates: Partial<Slate>[]): Promise<Slate[]> {
     return this._client.createSlates({ slates });
   }
 

--- a/lib/client/services/liveStreamEvent/liveStreamEventService.interface.ts
+++ b/lib/client/services/liveStreamEvent/liveStreamEventService.interface.ts
@@ -38,7 +38,7 @@ export interface LiveStreamEventServiceOperations {
    *
    * @param slates 	list of slate objects to create.
    */
-  createSlates(slates: Slate[]): Promise<Slate[]>;
+  createSlates(slates: Partial<Slate>[]): Promise<Slate[]>;
   /**
    * Gets a {@link https://developers.google.com/ad-manager/api/reference/v202405/LiveStreamEventService.LiveStreamEventPage LiveStreamEventPage}
    * of {@link https://developers.google.com/ad-manager/api/reference/v202405/LiveStreamEventService.LiveStreamEvent LiveStreamEvent} objects that satisfy the given

--- a/lib/client/services/nativeStyle/nativeStyleService.interface.ts
+++ b/lib/client/services/nativeStyle/nativeStyleService.interface.ts
@@ -12,7 +12,9 @@ export interface NativeStyleServiceOperations {
    * @param nativeStyles the native styles to create
    * @returns the created native styles with their IDs filled in
    */
-  createNativeStyles(nativeStyles: NativeStyle[]): Promise<NativeStyle[]>;
+  createNativeStyles(
+    nativeStyles: Partial<NativeStyle>[],
+  ): Promise<NativeStyle[]>;
   /**
    * Gets a {@link https://developers.google.com/ad-manager/api/reference/v202405/NativeStyleService.NativeStylePage NativeStylePage}
    * of {@link https://developers.google.com/ad-manager/api/reference/v202405/NativeStyleService.NativeStyle NativeStyle} objects that satisfy the given

--- a/lib/client/services/order/order.service.ts
+++ b/lib/client/services/order/order.service.ts
@@ -11,7 +11,7 @@ export class OrderService implements OrderServiceOperations {
     this._client = client;
   }
 
-  async createOrders(orders: Order[]): Promise<Order[]> {
+  async createOrders(orders: Partial<Order>[]): Promise<Order[]> {
     return this._client.createOrders({ orders });
   }
 

--- a/lib/client/services/order/orderService.interface.ts
+++ b/lib/client/services/order/orderService.interface.ts
@@ -16,7 +16,7 @@ export interface OrderServiceOperations {
    * @param orders the orders to create
    * @returns the created orders with their IDs filled in
    */
-  createOrders(orders: Order[]): Promise<Order[]>;
+  createOrders(orders: Partial<Order>[]): Promise<Order[]>;
   /**
    * Gets an {@link https://developers.google.com/ad-manager/api/reference/v202405/OrderService.OrderPage OrderPage} of
    * {@link https://developers.google.com/ad-manager/api/reference/v202405/OrderService.Order Order}

--- a/lib/client/services/placement/placement.service.ts
+++ b/lib/client/services/placement/placement.service.ts
@@ -11,7 +11,9 @@ export class PlacementService implements PlacementServiceOperations {
     this._client = client;
   }
 
-  async createPlacements(placements: Placement[]): Promise<Placement[]> {
+  async createPlacements(
+    placements: Partial<Placement>[],
+  ): Promise<Placement[]> {
     return this._client.createPlacements({ placements });
   }
 

--- a/lib/client/services/placement/placementService.interface.ts
+++ b/lib/client/services/placement/placementService.interface.ts
@@ -15,7 +15,7 @@ export interface PlacementServiceOperations {
    * @param placements the placements to create
    * @returns the created placements with their IDs filled in
    */
-  createPlacements(placements: Placement[]): Promise<Placement[]>;
+  createPlacements(placements: Partial<Placement>[]): Promise<Placement[]>;
   /**
    * Gets a {@link https://developers.google.com/ad-manager/api/reference/v202405/PlacementService.PlacementPage PlacementPage}
    * of {@link https://developers.google.com/ad-manager/api/reference/v202405/PlacementService.Placement Placement} objects that satisfy the given

--- a/lib/client/services/proposal/proposal.service.ts
+++ b/lib/client/services/proposal/proposal.service.ts
@@ -15,7 +15,7 @@ export class ProposalService implements ProposalServiceOperations {
     this._client = client;
   }
 
-  async createProposals(proposals: Proposal[]): Promise<Proposal[]> {
+  async createProposals(proposals: Partial<Proposal>[]): Promise<Proposal[]> {
     return this._client.createProposals({ proposals });
   }
 

--- a/lib/client/services/proposal/proposalService.interface.ts
+++ b/lib/client/services/proposal/proposalService.interface.ts
@@ -19,7 +19,7 @@ export interface ProposalServiceOperations {
    * @param proposals the proposals to create
    * @returns the created proposals with their IDs filled in
    */
-  createProposals(proposals: Proposal[]): Promise<Proposal[]>;
+  createProposals(proposals: Partial<Proposal>[]): Promise<Proposal[]>;
   /**
    * Gets a {@link https://developers.google.com/ad-manager/api/reference/v202405/ProposalService.MarketplaceCommentPage MarketplaceCommentPage}
    * of {@link https://developers.google.com/ad-manager/api/reference/v202405/ProposalService.MarketplaceComment MarketplaceComment} objects that satisfy the given

--- a/lib/client/services/site/site.service.ts
+++ b/lib/client/services/site/site.service.ts
@@ -11,7 +11,7 @@ export class SiteService implements SiteServiceOperations {
     this._client = client;
   }
 
-  async createSites(sites: Site[]): Promise<Site[]> {
+  async createSites(sites: Partial<Site>[]): Promise<Site[]> {
     return this._client.createSites({ sites });
   }
 

--- a/lib/client/services/site/siteService.interface.ts
+++ b/lib/client/services/site/siteService.interface.ts
@@ -9,7 +9,7 @@ export interface SiteServiceOperations {
    * @param sites the sites to create
    * @returns the created sites with their IDs filled in
    */
-  createSites(sites: Site[]): Promise<Site[]>;
+  createSites(sites: Partial<Site>[]): Promise<Site[]>;
   /**
    * Gets a {@link https://developers.google.com/ad-manager/api/reference/v202405/SiteService.SitePage SitePage}
    * of {@link https://developers.google.com/ad-manager/api/reference/v202405/SiteService.Site Site} objects that satisfy the given

--- a/lib/client/services/team/team.service.ts
+++ b/lib/client/services/team/team.service.ts
@@ -11,7 +11,7 @@ export class TeamService implements TeamServiceOperations {
     this._client = client;
   }
 
-  async createTeams(teams: Team[]): Promise<Team[]> {
+  async createTeams(teams: Partial<Team>[]): Promise<Team[]> {
     return this._client.createTeams({ teams });
   }
 

--- a/lib/client/services/team/teamService.interface.ts
+++ b/lib/client/services/team/teamService.interface.ts
@@ -19,7 +19,7 @@ export interface TeamServiceOperations {
    * @param teams the teams to create
    * @returns the created teams with their IDs filled in
    */
-  createTeams(teams: Team[]): Promise<Team[]>;
+  createTeams(teams: Partial<Team>[]): Promise<Team[]>;
   /**
    * Gets a {@link https://developers.google.com/ad-manager/api/reference/v202405/TeamService.TeamPage TeamPage}
    * of {@link https://developers.google.com/ad-manager/api/reference/v202405/TeamService.Team Team} objects that satisfy the given

--- a/lib/client/services/user/user.service.ts
+++ b/lib/client/services/user/user.service.ts
@@ -11,7 +11,7 @@ export class UserService implements UserServiceOperations {
     this._client = client;
   }
 
-  async createUsers(users: User[]): Promise<User[]> {
+  async createUsers(users: Partial<User>[]): Promise<User[]> {
     return this._client.createUsers({ users });
   }
 

--- a/lib/client/services/user/userService.interface.ts
+++ b/lib/client/services/user/userService.interface.ts
@@ -16,7 +16,7 @@ export interface UserServiceOperations {
    * @param users the users to create
    * @returns the created users with their IDs filled in
    */
-  createUsers(users: User[]): Promise<User[]>;
+  createUsers(users: Partial<User>[]): Promise<User[]>;
   /**
    * Returns the {@link https://developers.google.com/ad-manager/api/reference/v202405/UserService.Role Role} objects that are defined for the users of the network.
    *


### PR DESCRIPTION
## What does this change?
The current types require all properties of the types to be present when creating things, but this isn't actually the case.

Going through all the types and properties, working out which ones are optional/required is quite a big job, I think making them all optional and relying on the api itself for validation make sense for now.

The SOAP WSDL actually has all properties as optional (minOccurs="0" on everything) too so I think it makes sense to match it, e.g. https://ads.google.com/apis/ads/publisher/v202405/LineItemService?wsdl