### PR TITLE
Add special attributes to custom targeting types

### DIFF
--- a/.changeset/smooth-toes-relate.md
+++ b/.changeset/smooth-toes-relate.md
@@ -1,0 +1,5 @@
+---
+"@guardian/google-admanager-api": major
+---
+
+Enforce special attributes needed by custom targeting interfaces

--- a/lib/client/common/types/customCriteria.type.ts
+++ b/lib/client/common/types/customCriteria.type.ts
@@ -8,6 +8,9 @@ import type {
  * A CustomCriteria object is used to perform custom criteria targeting on custom targeting keys of type CustomTargetingKey.Type.PREDEFINED or CustomTargetingKey.Type.FREEFORM.
  */
 export type CustomCriteria = {
+  attributes: {
+    "xsi:type": "CustomCriteria";
+  };
   /**
    * The CustomTargetingKey.id of the CustomTargetingKey object that was created using CustomTargetingService. This attribute is required.
    */
@@ -28,6 +31,9 @@ export type CustomCriteria = {
  * A CmsMetadataCriteria object is used to target CmsMetadataValue objects.
  */
 export type CmsMetadataCriteria = {
+  attributes: {
+    "xsi:type": "CmsMetadataCriteria";
+  };
   /**
    * The comparison operator. This attribute is required.
    */
@@ -43,6 +49,9 @@ export type CmsMetadataCriteria = {
  * An AudienceSegmentCriteria object is used to target AudienceSegment objects.
  */
 export type AudienceSegmentCriteria = {
+  attributes: {
+    "xsi:type": "AudienceSegmentCriteria";
+  };
   /**
    * The comparison operator. This attribute is required.
    */
@@ -58,6 +67,10 @@ export type AudienceSegmentCriteria = {
  * A CustomCriteriaSet comprises of a set of CustomCriteriaNode objects combined by the CustomCriteriaSet.LogicalOperator.logicalOperator. The custom criteria targeting tree is subject to the rules defined on Targeting.customTargeting.
  */
 export type CustomCriteriaSet = {
+  attributes: {
+    "xsi:type": "CustomCriteriaSet";
+  };
+
   /**
    * The logical operator to be applied to CustomCriteriaSet.children. This attribute is required.
    */


### PR DESCRIPTION
## What does this change?
These attributes are required by the SOAP endpoint to create anything with custom targeting, something to do with the type of the customTargeting property in the WSDL, I figured out that they were required by looking at the [official Python SDK](https://github.com/googleads/googleads-python-lib/blob/main/examples/ad_manager/v202405/line_item_service/target_custom_criteria.py#L46).

This is technically a major change as it's a backwards incompatible change to the API.

