### PR TITLE
Add ability to log XML requests and responses

### DIFF
--- a/.changeset/slow-ants-fry.md
+++ b/.changeset/slow-ants-fry.md
@@ -1,0 +1,5 @@
+---
+"@guardian/google-admanager-api": minor
+---
+
+Add ability to log XML requests and responses

--- a/README.md
+++ b/README.md
@@ -97,3 +97,13 @@ const orderPage = await orderService.getOrdersByStatement(statement.toStatement(
     <td>An arbitrary string name identifying your application. This will be shown in Google's log files. For example: "My Inventory Application" or "App_1" (<b>optional</b>).</td>
   </tr>
 </table>
+
+### Debugging
+
+Enable request and response logging by setting `logRequests` and/or `logResponses` to `true` on the service object.
+
+```typescript
+const orderService = await adManagerClient.getService("OrderService");
+orderService.logRequests = true;
+orderService.logResponses = true;
+```

--- a/lib/client/adManager.client.ts
+++ b/lib/client/adManager.client.ts
@@ -8,6 +8,8 @@ export class AdManagerClient {
   private networkCode: number;
   private credential: SACredential;
   protected applicationName: string;
+  logRequests = false;
+  logResponses = false;
 
   constructor(
     networkCode: number,
@@ -29,7 +31,7 @@ export class AdManagerClient {
         networkCode: this.networkCode,
         token: token,
         applicationName: this.applicationName,
-      }).createClient();
+      }).createClient(this.logRequests, this.logResponses);
     } catch (err: any) {
       throw new Error(err);
     }

--- a/lib/client/googleSoap.service.ts
+++ b/lib/client/googleSoap.service.ts
@@ -18,7 +18,10 @@ export class GoogleSoapService<T extends keyof typeof SERVICE_MAP> {
     this.token = options.token;
   }
 
-  public async createClient(): Promise<ImportClass<typeof SERVICE_MAP, T>> {
+  public async createClient(
+    logRequests = false,
+    logResponses = false,
+  ): Promise<ImportClass<typeof SERVICE_MAP, T>> {
     const serviceUrl = `https://ads.google.com/apis/ads/publisher/${API_VERSION}/${this.service}?wsdl`;
     const client = await createClientAsync(serviceUrl);
     client.addSoapHeader(this.getSoapHeaders());
@@ -27,6 +30,18 @@ export class GoogleSoapService<T extends keyof typeof SERVICE_MAP> {
     };
 
     if (this.token) client.setToken(this.token);
+
+    if (logRequests) {
+      client.addListener("request", (req: unknown) => {
+        console.info("SOAP Request:", req);
+      });
+    }
+
+    if (logResponses) {
+      client.addListener("response", (res: unknown) => {
+        console.info("SOAP Response:", res);
+      });
+    }
 
     this._client = new Proxy(client, {
       get: function get(target, propertyKey) {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Add ability to toggle logging XML requests and responses on the services.