### PR TITLE
feat: Support defining API version

### DIFF
--- a/.changeset/pretty-badgers-fly.md
+++ b/.changeset/pretty-badgers-fly.md
@@ -1,0 +1,5 @@
+---
+"@guardian/google-admanager-api": minor
+---
+
+feat: Support defining Google Ad Manager API version

--- a/README.md
+++ b/README.md
@@ -32,14 +32,14 @@ All Google Ad Manager API calls must be authorized through OAuth2 an open standa
 ```typescript
 
 const credential = new GoogleSACredential({
-    "type": "service_account",
-    "project_id": "...",
-    "private_key_id": "...",
-    "private_key": "...",
-    "client_email": "...",
-    "client_id": "...",
-    "auth_uri": "...",
-    "token_uri": "...",
+    type: "service_account",
+    project_id: "...",
+    private_key_id: "...",
+    private_key: "...",
+    client_email: "...",
+    client_id: "...",
+    auth_uri: "...",
+    token_uri: "...",
     ...
 });
 
@@ -127,7 +127,7 @@ lineItemService.createLineitem({
   ...
 })
 
-//must be
+// must be
 lineItemService.createLineitem({
   orderId: 123,
   priority: 12,
@@ -136,9 +136,9 @@ lineItemService.createLineitem({
 ```
 
 #### Some objects need additional attributes
-In some cases where multiple shapes of objects are accepted, the type need to be speficied under a special `attributes` property.
+In some cases where multiple shapes of objects are accepted, the type need to be specified under a special `attributes` property.
 
-For example for custom targeting the objects need to have their type specified whether they are a `CustomCriteriaSet` or `CustomTargeting` like so:
+For example, for custom targeting, the objects need to have their type specified whether they are a `CustomCriteriaSet` or `CustomTargeting` like so:
 ```ts
 const customTargeting: CustomCriteriaSet = {
   attributes: {

--- a/README.md
+++ b/README.md
@@ -96,6 +96,11 @@ const orderPage = await orderService.getOrdersByStatement(statement.toStatement(
     <td><code>String</code></td>
     <td>An arbitrary string name identifying your application. This will be shown in Google's log files. For example: "My Inventory Application" or "App_1" (<b>optional</b>).</td>
   </tr>
+    <tr>
+    <td><code><b>apiVersion</b></code></td>
+    <td><code>String</code></td>
+    <td>Ad Mananger API version, if you want to define a different version than the default one (<b>optional</b>).</td>
+  </tr>
 </table>
 
 ### Debugging

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ const orderPage = await orderService.getOrdersByStatement(statement.toStatement(
     <tr>
     <td><code><b>apiVersion</b></code></td>
     <td><code>String</code></td>
-    <td>Ad Mananger API version, if you want to define a different version than the default one (<b>optional</b>).</td>
+    <td>Ad Mananger API version, if you want to define a different version than the default version, i.e. v202405 (<b>optional</b>).</td>
   </tr>
 </table>
 

--- a/lib/client/adManager.client.ts
+++ b/lib/client/adManager.client.ts
@@ -1,6 +1,9 @@
 import type { SACredential } from "../auth";
 import type { SERVICE_MAP } from "../common/constants";
-import { DEFAULT_APPLICATION_NAME } from "../common/constants";
+import {
+  DEFAULT_APPLICATION_NAME,
+  DEFAULT_API_VERSION,
+} from "../common/constants";
 import type { ImportClass } from "../common/types";
 import { GoogleSoapService } from "./googleSoap.service";
 
@@ -8,6 +11,7 @@ export class AdManagerClient {
   private networkCode: number;
   private credential: SACredential;
   protected applicationName: string;
+  protected apiVersion: string;
   logRequests = false;
   logResponses = false;
 
@@ -15,10 +19,12 @@ export class AdManagerClient {
     networkCode: number,
     credential: SACredential,
     applicationName?: string,
+    apiVersion?: string,
   ) {
     this.networkCode = networkCode;
     this.credential = credential;
     this.applicationName = applicationName || DEFAULT_APPLICATION_NAME;
+    this.apiVersion = apiVersion || DEFAULT_API_VERSION;
   }
 
   async getService<T extends keyof typeof SERVICE_MAP>(
@@ -31,6 +37,7 @@ export class AdManagerClient {
         networkCode: this.networkCode,
         token: token,
         applicationName: this.applicationName,
+        apiVersion: this.apiVersion,
       }).createClient(this.logRequests, this.logResponses);
     } catch (err: any) {
       throw new Error(err);

--- a/lib/client/googleSoap.service.ts
+++ b/lib/client/googleSoap.service.ts
@@ -27,7 +27,7 @@ export class GoogleSoapService<T extends keyof typeof SERVICE_MAP> {
     const serviceUrl = `https://ads.google.com/apis/ads/publisher/${this.apiVersion}/${this.service}?wsdl`;
     console.log("MENDEL", serviceUrl);
     const client = await createClientAsync(serviceUrl);
-    client.addSoapHeader(this.getSoapHeaders(this.apiVersion));
+    client.addSoapHeader(this.getSoapHeaders());
     client.setToken = function setToken(token: string) {
       client.setSecurity(new BearerSecurity(token));
     };
@@ -68,7 +68,7 @@ export class GoogleSoapService<T extends keyof typeof SERVICE_MAP> {
     return new services[this.service](this._client);
   }
 
-  private getSoapHeaders(apiVersion: string): any {
+  private getSoapHeaders(): any {
     return {
       RequestHeader: {
         attributes: {
@@ -76,7 +76,7 @@ export class GoogleSoapService<T extends keyof typeof SERVICE_MAP> {
           "soapenv:mustUnderstand": 0,
           "xsi:type": "ns1:SoapRequestHeader",
           "xmlns:ns1":
-            "https://www.google.com/apis/ads/publisher/" + apiVersion,
+            "https://www.google.com/apis/ads/publisher/" + this.apiVersion,
           "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
           "xmlns:soapenv": "http://schemas.xmlsoap.org/soap/envelope/",
         },

--- a/lib/client/googleSoap.service.ts
+++ b/lib/client/googleSoap.service.ts
@@ -25,7 +25,6 @@ export class GoogleSoapService<T extends keyof typeof SERVICE_MAP> {
     logResponses = false,
   ): Promise<ImportClass<typeof SERVICE_MAP, T>> {
     const serviceUrl = `https://ads.google.com/apis/ads/publisher/${this.apiVersion}/${this.service}?wsdl`;
-    console.log("MENDEL", serviceUrl);
     const client = await createClientAsync(serviceUrl);
     client.addSoapHeader(this.getSoapHeaders());
     client.setToken = function setToken(token: string) {

--- a/lib/common/constants/index.ts
+++ b/lib/common/constants/index.ts
@@ -4,4 +4,4 @@ export { SERVICE_MAP };
 
 export const SCOPE = "https://www.googleapis.com/auth/dfp";
 export const DEFAULT_APPLICATION_NAME = "applicationName";
-export const API_VERSION = "v202405";
+export const DEFAULT_API_VERSION = "v202405";

--- a/lib/common/types/googleSoapService.type.ts
+++ b/lib/common/types/googleSoapService.type.ts
@@ -10,6 +10,10 @@ export type GoogleSoapServiceOptions = {
    */
   applicationName: string;
   /**
+   * Ad Mananger API version
+   */
+  apiVersion: string;
+  /**
    *  OAuth2 access token
    */
   token: string;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR allows a user of this package to define their own version of the Ad Manager API, if they prefer to, instead of only allowing a hardcoded version (which is currently v202405 - one version behind the latest).

## How to test

Run the Ad Manager client with both a defined version and leaving undefined (relying on default) and see that calls complete successfully.


*Your consideration and review is most appreciated!* 🙌🏼