### PR TITLE
Update `endDateTime` and `targeting` types

### DIFF
--- a/.changeset/few-donuts-juggle.md
+++ b/.changeset/few-donuts-juggle.md
@@ -1,0 +1,5 @@
+---
+"@guardian/google-admanager-api": minor
+---
+
+endDateTime, customTargeting, deviceCategoryTargeting and geoTargeting to be optional as they are sometime not present in responses.

--- a/lib/client/common/types/lineItemSummary.type.ts
+++ b/lib/client/common/types/lineItemSummary.type.ts
@@ -141,7 +141,7 @@ export type LineItemSummary = {
    * The date and time on which the LineItem will stop serving. This attribute is required unless LineItem.unlimitedEndDateTime is set to true.
    * If specified, it must be after the LineItem.startDateTime. This end date and time does not include auto extension days.
    */
-  endDateTime: DateTime;
+  endDateTime?: DateTime;
 
   /**
    * The number of days to allow a line item to deliver past its endDateTime. A maximum of 7 days is allowed. This is feature is only available for Ad Manager 360 accounts.

--- a/lib/client/common/types/targeting.type.ts
+++ b/lib/client/common/types/targeting.type.ts
@@ -49,12 +49,12 @@ export type GeoTargeting = {
   /**
    * The geographical locations being targeted by the LineItem.
    */
-  targetedLocations: Location[];
+  targetedLocations?: Location[];
 
   /**
    * The geographical locations being excluded by the LineItem.
    */
-  excludedLocations: Location[];
+  excludedLocations?: Location[];
 };
 
 /**
@@ -216,12 +216,12 @@ export type DeviceCategoryTargeting = {
   /**
    * Device categories that are being targeted by the LineItem.
    */
-  targetedDeviceCategories: Technology[];
+  targetedDeviceCategories?: Technology[];
 
   /**
    * Device categories that are being excluded by the LineItem.
    */
-  excludedDeviceCategories: Technology[];
+  excludedDeviceCategories?: Technology[];
 };
 
 /**
@@ -341,7 +341,7 @@ export type TechnologyTargeting = {
   /**
    * The device categories being targeted by the LineItem.
    */
-  deviceCategoryTargeting: DeviceCategoryTargeting;
+  deviceCategoryTargeting?: DeviceCategoryTargeting;
 
   /**
    * The device manufacturers being targeted by the LineItem.
@@ -518,7 +518,7 @@ export type Targeting = {
    *
    * The third level can only comprise of CustomCriteria objects.
    */
-  customTargeting: CustomCriteriaSet;
+  customTargeting?: CustomCriteriaSet;
 
   /**
    * Specifies the domains or subdomains that are targeted or excluded by the LineItem. Users visiting from an IP address associated with those domains will be targeted or excluded. This attribute is optional.


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

This PR updates `endDateTime`, `customTargeting`, `deviceCategoryTargeting` and `geoTargeting` and their attributes to be optional as they are sometime not present in responses.

Those changes were discovered during my work on DFP line item jobs migration from Scala to TypeScript. 

It would be good to have the latest version in the new repo for DFP line item jobs instead of having committed code for disabling the `typescript-eslint/unnecessary-condition` rule.
