### PR TITLE
Force corepack version to fix CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
+      # Temporarily force newer version of corepack
+      # See https://github.com/guardian/support-service-lambdas/pull/2666
+      - run: npm install --global corepack@0.31.0
+
       - name: Set up Node
         uses: ./.github/actions/setup-node-env
 
@@ -27,6 +31,10 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
+
+      # Temporarily force newer version of corepack
+      # See https://github.com/guardian/support-service-lambdas/pull/2666
+      - run: npm install --global corepack@0.31.0
 
       - name: Set up Node
         uses: ./.github/actions/setup-node-env
@@ -44,6 +52,10 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
+      # Temporarily force newer version of corepack
+      # See https://github.com/guardian/support-service-lambdas/pull/2666
+      - run: npm install --global corepack@0.31.0
+
       - name: Set up Node
         uses: ./.github/actions/setup-node-env
 
@@ -56,6 +68,10 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
+
+      # Temporarily force newer version of corepack
+      # See https://github.com/guardian/support-service-lambdas/pull/2666
+      - run: npm install --global corepack@0.31.0
 
       - name: Set up Node
         uses: ./.github/actions/setup-node-env
@@ -81,6 +97,10 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+
+      # Temporarily force newer version of corepack
+      # See https://github.com/guardian/support-service-lambdas/pull/2666
+      - run: npm install --global corepack@0.31.0
 
       - name: Set up Node
         uses: ./.github/actions/setup-node-env


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

This PR is to fix `corepack` in CI which is causes failing builds https://github.com/guardian/google-admanager-api/actions/runs/13178898620/job/36784637827?pr=29

The fix is inspired by https://github.com/guardian/support-service-lambdas/pull/2666 and has been implemented in https://github.com/guardian/ad-manager-line-items-jobs/pull/19/files and https://github.com/guardian/commercial/pull/1774

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

The build in this PR passes. 
