### PR TITLE
Add beta release workflow

### DIFF
--- a/.github/workflows/beta-release-on-label.yml
+++ b/.github/workflows/beta-release-on-label.yml
@@ -1,0 +1,98 @@
+name: Publish Beta Package
+
+# This workflow is triggered on a label being added to a PR, and will publish a beta version of the bundle to npm
+# Use `pnpm changeset add` to add a new change
+# This action will release the changeset as a pre-release, and add a comment to the PR with the version number
+on:
+  pull_request:
+    types: [labeled]
+
+permissions: write-all
+
+jobs:
+  has-permission:
+    name: Check permissions
+    runs-on: ubuntu-latest
+    if: github.event.label.name == '[beta] @guardian/google-admanager-api'
+    steps:
+      - name: Check if organization member
+        id: is_organization_member
+        uses: JamesSingleton/is-organization-member@1.0.1
+        with:
+          organization: guardian
+          username: ${{ github.actor }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  release:
+    name: "@guardian/google-admanager-api"
+    runs-on: ubuntu-latest
+    needs: has-permission
+    if: github.event.label.name == '[beta] @guardian/google-admanager-api'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+
+      # Temporarily force newer version of corepack
+      # See https://github.com/guardian/support-service-lambdas/pull/2666
+      - run: npm install --global corepack@0.31.0
+
+      - name: Set up Node
+        uses: ./.github/actions/setup-node-env
+
+      - name: Build package
+        run: pnpm build
+
+      - name: Version
+        run: pnpm changeset version --snapshot beta
+
+      - name: Create Release
+        uses: changesets/action@v1.4.9
+        id: changeset
+        with:
+          publish: pnpm changeset publish --tag beta
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Comment on PR
+        uses: actions/github-script@v7.0.1
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const publishedPackages = ${{ steps.changeset.outputs.publishedPackages }};
+
+            if(publishedPackages.length === 0) {
+              throw new Error('No packages published, did you forget to add a changeset?');
+            }
+
+            const version = publishedPackages[0].version;
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `🚀 \`${version}\` published to npm as a beta release
+
+            To install the beta version, run one of the following commands in your project directory:
+            \`\`\`
+            npm install @guardian/google-admanager-api@${version}
+            pnpm add @guardian/google-admanager-api@${version}
+            yarn add @guardian/google-admanager-api@${version}
+            \`\`\`
+            `
+            })
+
+      - name: Remove label
+        uses: actions/github-script@v7.0.1
+        if: always()
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.rest.issues.removeLabel({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: '[beta] @guardian/google-admanager-api'
+            })


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Add a new github action that will enable us to publish beta versions to npm from PRs by adding a `[beta] @guardian/google-admanager-api` label.