### PR TITLE
Add commercial-dev as codeowners of this repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @guardian/commercial-dev


### PR DESCRIPTION
## What does this change?

Adds a `CODEOWNERS` file with the @guardian/commercial-dev team as default code owners of all files in the repo