### PR TITLE
feature: add inventorySizeTargeting to Targeting object

### DIFF
--- a/lib/client/common/types/targeting.type.ts
+++ b/lib/client/common/types/targeting.type.ts
@@ -31,6 +31,7 @@ import {
   VideoPositionTargetingStruct,
   type VideoPositionTargeting,
 } from "./videoPosition.type";
+import { Size } from "./general.type";
 
 /**
  * A {@link https://developers.google.com/ad-manager/api/reference/v202405/AdjustmentService.Location Location} represents a geographical entity that can be targeted.
@@ -848,6 +849,25 @@ export type InventoryUrlTargeting = {
 };
 
 /**
+ * A collection of targeted inventory urls.
+ */
+export type InventorySizeTargeting = {
+  /**
+   * Whether the inventory sizes should be targeted or excluded.
+   */
+  isTargeted: boolean;
+
+  /**
+   * A list of TargetedSizeDtos.
+   */
+  targetedSizes: TargetedSize[];
+};
+
+export type TargetedSize = {
+  size: Size;
+};
+
+/**
  * Represents an InventoryUrlTargeting struct.
  */
 export const InventoryUrlTargetingStruct: Describe<InventoryUrlTargeting> =
@@ -962,6 +982,13 @@ export type Targeting = {
    * This value is read-only for video line items generated from proposal line items.
    */
   requestPlatformTargeting?: RequestPlatformTargeting | null;
+
+  /**
+   * Specifies the sizes that are targeted by the entity.
+   *
+   * This is currently only supported on YieldGroup and TrafficDataRequest.
+   */
+  inventorySizeTargeting?: InventorySizeTargeting;
 };
 
 /**

--- a/lib/client/services/forecast/forecast.type.ts
+++ b/lib/client/services/forecast/forecast.type.ts
@@ -19,7 +19,7 @@ export type ProspectiveLineItem = {
    * predicting what would happen if it were added to the network. If a line item already exists with LineItem.id,
    * the forecast is computed for the subject, predicting what would happen if the existing line item's settings were modified to match the subject.
    */
-  lineItem: LineItem;
+  lineItem?: LineItem;
 
   /**
    * The target of the forecast if this prospective line item is a proposal line item.
@@ -34,12 +34,12 @@ export type ProspectiveLineItem = {
    *
    * Either lineItem or proposalLineItem should be specified but not both.
    */
-  proposalLineItem: ProposalLineItem;
+  proposalLineItem?: ProposalLineItem;
 
   /**
    * When set, the line item is assumed to be from this advertiser, and unified blocking rules will apply accordingly. If absent, line items without an existing order won't be subject to unified blocking rules.
    */
-  advertiserId: number;
+  advertiserId?: number;
 };
 
 /**


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

- Added the `inventorySizeTargeting` property, of type [InventorySizeTargeting](https://developers.google.com/ad-manager/api/reference/v202502/ForecastService.InventorySizeTargeting), to the [Targeting](https://developers.google.com/ad-manager/api/reference/v202502/ForecastService.Targeting) object, which was missing for the latest implementation.
- In [ProspectiveLineItem](https://developers.google.com/ad-manager/api/reference/v202502/ForecastService.ProspectiveLineItem) you should specify either a `lineItem` or a `prospectiveLineItem`, but not both. Given that both properties where mandatory, it was not possible to do it.
- Finally, still in [ProspectiveLineItem](https://developers.google.com/ad-manager/api/reference/v202502/ForecastService.ProspectiveLineItem), `advertiserId` is optional, so it should also be optional in the object itself.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Create a sample [getAvailabilityForecast](https://developers.google.com/ad-manager/api/reference/v202502/ForecastService#getavailabilityforecast) request, by specifying either a `lineItem` or a `proposalLineItem`, and also by adding an `inventorySizeTargeting` to the targeting object.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
