### PR TITLE
Add changeset to bump version of soap

### DIFF
--- a/.changeset/red-cameras-lose.md
+++ b/.changeset/red-cameras-lose.md
@@ -1,0 +1,5 @@
+---
+"@guardian/google-admanager-api": patch
+---
+
+Bump version of soap to 1.1.11 in dependencies


### PR DESCRIPTION
## What does this change?

Adds changeset for upgrading version of `soap` in dependencies

## Why

It was missed when merging the dependabot PR https://github.com/guardian/google-admanager-api/pull/60