### PR TITLE
Remove hardcoded version of `corepack` in Github workflows

### DIFF
--- a/.github/workflows/beta-release-on-label.yml
+++ b/.github/workflows/beta-release-on-label.yml
@@ -34,10 +34,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Temporarily force newer version of corepack
-      # See https://github.com/guardian/support-service-lambdas/pull/2666
-      - run: npm install --global corepack@0.31.0
-
       - name: Set up Node
         uses: ./.github/actions/setup-node-env
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,6 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      # Temporarily force newer version of corepack
-      # See https://github.com/guardian/support-service-lambdas/pull/2666
-      - run: npm install --global corepack@0.31.0
-
       - name: Set up Node
         uses: ./.github/actions/setup-node-env
 
@@ -31,10 +27,6 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
-
-      # Temporarily force newer version of corepack
-      # See https://github.com/guardian/support-service-lambdas/pull/2666
-      - run: npm install --global corepack@0.31.0
 
       - name: Set up Node
         uses: ./.github/actions/setup-node-env
@@ -52,10 +44,6 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      # Temporarily force newer version of corepack
-      # See https://github.com/guardian/support-service-lambdas/pull/2666
-      - run: npm install --global corepack@0.31.0
-
       - name: Set up Node
         uses: ./.github/actions/setup-node-env
 
@@ -68,10 +56,6 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
-
-      # Temporarily force newer version of corepack
-      # See https://github.com/guardian/support-service-lambdas/pull/2666
-      - run: npm install --global corepack@0.31.0
 
       - name: Set up Node
         uses: ./.github/actions/setup-node-env
@@ -97,10 +81,6 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-
-      # Temporarily force newer version of corepack
-      # See https://github.com/guardian/support-service-lambdas/pull/2666
-      - run: npm install --global corepack@0.31.0
 
       - name: Set up Node
         uses: ./.github/actions/setup-node-env


### PR DESCRIPTION
## What does this change?

Unsets hardcoded version of `corepack` in the Github workflows. It shouldn't be needed any more
