### PR TITLE
adds createTargetingPresets method to class

### DIFF
--- a/.changeset/three-fans-smash.md
+++ b/.changeset/three-fans-smash.md
@@ -1,0 +1,5 @@
+---
+"@guardian/google-admanager-api": patch
+---
+
+Updates the TargetingPresetService class by including the createTargetingPresets method

--- a/lib/client/services/targetingPresent/targetingPresent.service.ts
+++ b/lib/client/services/targetingPresent/targetingPresent.service.ts
@@ -1,6 +1,9 @@
 import type { Client } from "soap";
 import type { Statement } from "../../../common/types";
-import type { TargetingPresetPage } from "./targetingPresent.type";
+import type {
+  TargetingPreset,
+  TargetingPresetPage,
+} from "./targetingPresent.type";
 import type { TargetingPresetServiceOperations } from "./targetingPresentService.interface";
 
 export class TargetingPresetService
@@ -18,5 +21,11 @@ export class TargetingPresetService
     return this._client.getTargetingPresetsByStatement({
       filterStatement,
     });
+  }
+
+  async createTargetingPresets(
+    targetingPresets: TargetingPreset[],
+  ): Promise<TargetingPreset[]> {
+    return this._client.createTargetingPresets({ targetingPresets });
   }
 }

--- a/lib/client/services/targetingPresent/targetingPresent.type.ts
+++ b/lib/client/services/targetingPresent/targetingPresent.type.ts
@@ -1,4 +1,5 @@
 import type { PageResult } from "../../../common/types";
+import { Targeting } from "../../common/types";
 
 /**
  * Represents targeted or excluded ad units.
@@ -13,6 +14,22 @@ export type AdUnitTargeting = {
    */
   includeDescendants: boolean;
 };
+
+
+export type TargetingPreset = {
+  id: number;
+  /**
+   * The unique ID of the TargetingPreset. This value is readonly and is assigned by Google.
+   */
+  name: string;
+  /**
+   * The name of the TargetingPreset. This value is required to create a targeting preset and has a maximum length of 255 characters.
+   */
+  targeting: Targeting;
+  /**
+   * Contains the targeting criteria for the TargetingPreset. This attribute is required.
+   */
+}
 
 /**
  * Captures a paged query of TargetingPresetDto objects.


### PR DESCRIPTION
…class

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
In order to allow our internal tool [ad-manager-tools](https://github.com/guardian/ad-manager-tools) to create targeting presets from a script, we need to expose from this repo the appropriate method.

This PR adds that very method to the exposed class, to be consumed by `ad-manage-tools`
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Beta Release the feature addition, and consume that beta version.
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
We should be able to access the method in code, allowing us to create a script to create targeting presets.
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
