### PR TITLE
update BaseCreativeTemplateVariableValue export type

### DIFF
--- a/.changeset/green-views-greet.md
+++ b/.changeset/green-views-greet.md
@@ -1,0 +1,5 @@
+---
+"@guardian/google-admanager-api": minor
+---
+
+updates the type exports for Creatives

--- a/lib/client/services/creative/creative.type.ts
+++ b/lib/client/services/creative/creative.type.ts
@@ -976,13 +976,26 @@ export type UrlCreativeTemplateVariableValue = {
  */
 export type BaseCreativeTemplateVariableValue = {
   /**
+   * Metadata field indicating the type of the CreativeTemplateVariable
+   */
+  attributes: {
+    "xsi:type":
+      | "AssetCreativeTemplateVariableValue"
+      | "LongCreativeTemplateVariableValue"
+      | "StringCreativeTemplateVariableValue"
+      | "ListStringCreativeTemplateVariableValue"
+      | "UrlCreativeTemplateVariableValue";
+  };
+  /**
    * A uniqueName of the CreativeTemplateVariable.
    */
   uniqueName: string;
-} & AssetCreativeTemplateVariableValue &
-  LongCreativeTemplateVariableValue &
-  StringCreativeTemplateVariableValue &
-  UrlCreativeTemplateVariableValue;
+} & (
+  | AssetCreativeTemplateVariableValue
+  | LongCreativeTemplateVariableValue
+  | StringCreativeTemplateVariableValue
+  | UrlCreativeTemplateVariableValue
+);
 
 /**
  * A Creative that is created by the specified creative template.


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Updates BaseCreativeTemplateVariableValue so it is in line with the google SOAP api docs.

This will allow the creatives to be appropriately typed in the `line-item-jobs` work: PR here https://github.com/guardian/line-item-jobs/pull/124
