### PR TITLE
Update dependabot schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,8 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "monday"
       time: "09:00"
     groups:
       linters:
@@ -38,4 +39,4 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"


### PR DESCRIPTION
## What does this change?

Updates the dependabot schedule to raise PRs once a week (on Mondays) instead of daily

## Why?

Reducing alert fatigue and PR merging frequency (we don't need to merge every single patch change to a package). 
We don't need this repo to be updated daily so let's reduce the frequency of these PRs.
