### PR TITLE
Bump Google Ad Manager SOAP API version to v202605

### DIFF
--- a/.changeset/jolly-pans-kneel.md
+++ b/.changeset/jolly-pans-kneel.md
@@ -1,0 +1,14 @@
+---
+"@guardian/google-admanager-api": major
+---
+
+Updates to track v202605 of the Google Ad Manager Soap API
+
+- Adds new fields from v202511 of the GAM SOAP API:
+  - Creatives: Added ThirdPartyDataDeclarationStatus
+  - Line Items: Added PublisherProvidedSignalsTargeting
+  - Companies: Added verifiedExchangeAdvertiserdId
+- Removes settings field from Company type
+- Adds deliveryAllocationProfileId to LineItemSummary and ProposalLineItem types
+
+- Switches the default version of the GAM API to v202605 (the latest version available at the time)

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ const orderPage = await orderService.getOrdersByStatement(statement.toStatement(
     <tr>
     <td><code><b>apiVersion</b></code></td>
     <td><code>String</code></td>
-    <td>Ad Mananger API version, if you want to define a different version than the default version, i.e. v202505 (<b>optional</b>).</td>
+    <td>Ad Mananger API version, if you want to define a different version than the default version, i.e. v202605 (<b>optional</b>).</td>
   </tr>
 </table>
 

--- a/lib/client/common/types/general.type.ts
+++ b/lib/client/common/types/general.type.ts
@@ -22,15 +22,40 @@ import {
 } from "../enums";
 
 /**
+ * The status of the ThirdPartyDataDeclaration associated with a given creative.
+ *
+ * This is calculated by comparing the companies detected via automated scanning/parsing, with the companies declared in the ThirdPartyDataDeclaration.
+ */
+export enum ThirdPartyDataDeclarationStatus {
+  /**
+   * The value returned if the actual value is not exposed by the requested API version. 
+   */
+  UNKNOWN = "UNKNOWN",
+  /**
+   * At least one detected ad technology provider wasn’t declared at the network level or on the creative's ThirdPartyDataDeclaration
+   */
+  INCOMPLETE = "INCOMPLETE",
+  /**
+   * All detected ad technology providers have been declared, either at the network level or on the creative's ThirdPartyDataDeclaration
+   */
+  COMPLETE = "COMPLETE",
+  /**
+   * This entity has not been recently scanned.
+   * There is either no scanning data for this creative, or the scanning data is stale. This can happen if the creative is not associated with any line items that are active or eligible to serve.
+   */
+  UNSCANNED = "UNSCANNED",
+}
+
+/**
  * Represents a set of declarations about what (if any) third party companies are associated with a given creative.
  *
  * This can be set at the network level, as a default for all creatives, or overridden for a particular creative.
- *
  */
 export type ThirdPartyDataDeclaration = {
   declarationType: DeclarationType;
   thirdPartyCompanyIds: number[];
 };
+
 
 export type ChildPublisher = {
   /**

--- a/lib/client/common/types/general.type.ts
+++ b/lib/client/common/types/general.type.ts
@@ -22,31 +22,6 @@ import {
 } from "../enums";
 
 /**
- * The status of the ThirdPartyDataDeclaration associated with a given creative.
- *
- * This is calculated by comparing the companies detected via automated scanning/parsing, with the companies declared in the ThirdPartyDataDeclaration.
- */
-export enum ThirdPartyDataDeclarationStatus {
-  /**
-   * The value returned if the actual value is not exposed by the requested API version. 
-   */
-  UNKNOWN = "UNKNOWN",
-  /**
-   * At least one detected ad technology provider wasn’t declared at the network level or on the creative's ThirdPartyDataDeclaration
-   */
-  INCOMPLETE = "INCOMPLETE",
-  /**
-   * All detected ad technology providers have been declared, either at the network level or on the creative's ThirdPartyDataDeclaration
-   */
-  COMPLETE = "COMPLETE",
-  /**
-   * This entity has not been recently scanned.
-   * There is either no scanning data for this creative, or the scanning data is stale. This can happen if the creative is not associated with any line items that are active or eligible to serve.
-   */
-  UNSCANNED = "UNSCANNED",
-}
-
-/**
  * Represents a set of declarations about what (if any) third party companies are associated with a given creative.
  *
  * This can be set at the network level, as a default for all creatives, or overridden for a particular creative.

--- a/lib/client/common/types/general.type.ts
+++ b/lib/client/common/types/general.type.ts
@@ -31,7 +31,6 @@ export type ThirdPartyDataDeclaration = {
   thirdPartyCompanyIds: number[];
 };
 
-
 export type ChildPublisher = {
   /**
    * Type of delegation the parent has been approved to have over the child.

--- a/lib/client/common/types/lineItemSummary.type.ts
+++ b/lib/client/common/types/lineItemSummary.type.ts
@@ -491,7 +491,7 @@ export type LineItemSummary = {
    */
   repeatedCreativeServingEnabled: boolean;
   /**
-   * The AllocationDeliveryProfile ID for this line item. 
+   * The AllocationDeliveryProfile ID for this line item.
    */
   deliveryAllocationProfileId?: number;
 };

--- a/lib/client/common/types/lineItemSummary.type.ts
+++ b/lib/client/common/types/lineItemSummary.type.ts
@@ -490,4 +490,8 @@ export type LineItemSummary = {
    * Indicates whether repeated creative serving is enabled for this line item.
    */
   repeatedCreativeServingEnabled: boolean;
+  /**
+   * The AllocationDeliveryProfile ID for this line item. 
+   */
+  deliveryAllocationProfileId?: number;
 };

--- a/lib/client/common/types/targeting.type.ts
+++ b/lib/client/common/types/targeting.type.ts
@@ -221,17 +221,17 @@ export const DayPartTargetingStruct: Describe<DayPartTargeting> = object({
 export type Technology = {
   attributes: {
     "xsi:type":
-    | "BandwidthGroup"
-    | "Browser"
-    | "BrowserLanguage"
-    | "DeviceCapability"
-    | "DeviceCategory"
-    | "DeviceManufacturer"
-    | "MobileCarrier"
-    | "MobileDevice"
-    | "MobileDeviceSubmodel"
-    | "OperatingSystem"
-    | "OperatingSystemVersion";
+      | "BandwidthGroup"
+      | "Browser"
+      | "BrowserLanguage"
+      | "DeviceCapability"
+      | "DeviceCategory"
+      | "DeviceManufacturer"
+      | "MobileCarrier"
+      | "MobileDevice"
+      | "MobileDeviceSubmodel"
+      | "OperatingSystem"
+      | "OperatingSystemVersion";
   };
   /**
    * The unique ID of the Technology. This value is required for all forms of TechnologyTargeting.

--- a/lib/client/common/types/targeting.type.ts
+++ b/lib/client/common/types/targeting.type.ts
@@ -221,17 +221,17 @@ export const DayPartTargetingStruct: Describe<DayPartTargeting> = object({
 export type Technology = {
   attributes: {
     "xsi:type":
-      | "BandwidthGroup"
-      | "Browser"
-      | "BrowserLanguage"
-      | "DeviceCapability"
-      | "DeviceCategory"
-      | "DeviceManufacturer"
-      | "MobileCarrier"
-      | "MobileDevice"
-      | "MobileDeviceSubmodel"
-      | "OperatingSystem"
-      | "OperatingSystemVersion";
+    | "BandwidthGroup"
+    | "Browser"
+    | "BrowserLanguage"
+    | "DeviceCapability"
+    | "DeviceCategory"
+    | "DeviceManufacturer"
+    | "MobileCarrier"
+    | "MobileDevice"
+    | "MobileDeviceSubmodel"
+    | "OperatingSystem"
+    | "OperatingSystemVersion";
   };
   /**
    * The unique ID of the Technology. This value is required for all forms of TechnologyTargeting.
@@ -951,6 +951,14 @@ export const InventorySizeTargetingStruct: Describe<InventorySizeTargeting> =
     ),
   });
 
+/**
+ * Publisher provided signals targeting information.
+ */
+export type PublisherProvidedSignalsTargeting = {
+  targetedTaxonomyCategoryIds?: number[];
+  excludedTaxonomyCategoryIds?: number[];
+};
+
 export type TargetedSize = {
   size: Size;
 };
@@ -1055,6 +1063,10 @@ export type Targeting = {
    * This is currently only supported on YieldGroup and TrafficDataRequest.
    */
   inventorySizeTargeting?: InventorySizeTargeting;
+  /**
+   * Publisher provided signals targeting information.
+   */
+  publisherProvidedSignalsTargeting?: PublisherProvidedSignalsTargeting;
 };
 
 /**

--- a/lib/client/services/company/company.type.ts
+++ b/lib/client/services/company/company.type.ts
@@ -76,10 +76,6 @@ export type Company = {
    */
   creditStatus: CompanyCreditStatus;
   /**
-   * Specifies the default billing settings of this Company. This attribute is optional.
-   */
-  settings: CompanySettings;
-  /**
    * The set of labels applied to this company.
    */
   appliedLabels?: AppliedLabel[];
@@ -95,6 +91,16 @@ export type Company = {
    * Specifies the ID of the Google-recognized canonicalized form of this company. This attribute is optional.
    */
   thirdPartyCompanyId: number;
+  /**
+   * The Google-recognized id for the canonicalized form of the company. This attribute is optional. 
+   */
+  verifiedExchangeAdvertiserId?: number;
+  /**
+   * A unique ID for the brand mapped to this company. A brand is a subdivision of an advertiser; 
+   * if the brand is set, the verifiedExchangeAdvertiserId representing the advertiser must also be set. 
+   * This attribute is optional. 
+   */
+  verifiedExchangeBrandId?: number;
   /**
    * The date and time this company was last modified.
    */

--- a/lib/client/services/company/company.type.ts
+++ b/lib/client/services/company/company.type.ts
@@ -92,13 +92,13 @@ export type Company = {
    */
   thirdPartyCompanyId: number;
   /**
-   * The Google-recognized id for the canonicalized form of the company. This attribute is optional. 
+   * The Google-recognized id for the canonicalized form of the company. This attribute is optional.
    */
   verifiedExchangeAdvertiserId?: number;
   /**
-   * A unique ID for the brand mapped to this company. A brand is a subdivision of an advertiser; 
-   * if the brand is set, the verifiedExchangeAdvertiserId representing the advertiser must also be set. 
-   * This attribute is optional. 
+   * A unique ID for the brand mapped to this company. A brand is a subdivision of an advertiser;
+   * if the brand is set, the verifiedExchangeAdvertiserId representing the advertiser must also be set.
+   * This attribute is optional.
    */
   verifiedExchangeBrandId?: number;
   /**

--- a/lib/client/services/creative/creative.enum.ts
+++ b/lib/client/services/creative/creative.enum.ts
@@ -652,3 +652,29 @@ export enum VastRedirectType {
    */
   LINEAR_AND_NON_LINEAR = "LINEAR_AND_NON_LINEAR",
 }
+
+
+/**
+ * The status of the ThirdPartyDataDeclaration associated with a given creative.
+ *
+ * This is calculated by comparing the companies detected via automated scanning/parsing, with the companies declared in the ThirdPartyDataDeclaration.
+ */
+export enum ThirdPartyDataDeclarationStatus {
+  /**
+   * The value returned if the actual value is not exposed by the requested API version. 
+   */
+  UNKNOWN = "UNKNOWN",
+  /**
+   * At least one detected ad technology provider wasn’t declared at the network level or on the creative's ThirdPartyDataDeclaration
+   */
+  INCOMPLETE = "INCOMPLETE",
+  /**
+   * All detected ad technology providers have been declared, either at the network level or on the creative's ThirdPartyDataDeclaration
+   */
+  COMPLETE = "COMPLETE",
+  /**
+   * This entity has not been recently scanned.
+   * There is either no scanning data for this creative, or the scanning data is stale. This can happen if the creative is not associated with any line items that are active or eligible to serve.
+   */
+  UNSCANNED = "UNSCANNED",
+}

--- a/lib/client/services/creative/creative.enum.ts
+++ b/lib/client/services/creative/creative.enum.ts
@@ -653,7 +653,6 @@ export enum VastRedirectType {
   LINEAR_AND_NON_LINEAR = "LINEAR_AND_NON_LINEAR",
 }
 
-
 /**
  * The status of the ThirdPartyDataDeclaration associated with a given creative.
  *
@@ -661,7 +660,7 @@ export enum VastRedirectType {
  */
 export enum ThirdPartyDataDeclarationStatus {
   /**
-   * The value returned if the actual value is not exposed by the requested API version. 
+   * The value returned if the actual value is not exposed by the requested API version.
    */
   UNKNOWN = "UNKNOWN",
   /**

--- a/lib/client/services/creative/creative.type.ts
+++ b/lib/client/services/creative/creative.type.ts
@@ -5,7 +5,6 @@ import type {
   BaseCustomFieldValue,
   Size,
   ThirdPartyDataDeclaration,
-  ThirdPartyDataDeclarationStatus,
 } from "../../common/types";
 import type { ConversionEvent_TrackingUrlsMapEntry } from "../creativeWrapper/creativeWrapper.type";
 import type {
@@ -22,6 +21,7 @@ import type {
   ScalableType,
   SslManualOverride,
   SslScanResult,
+  ThirdPartyDataDeclarationStatus,
   VastRedirectType,
   VideoDeliveryType,
 } from "./creative.enum";

--- a/lib/client/services/creative/creative.type.ts
+++ b/lib/client/services/creative/creative.type.ts
@@ -5,6 +5,7 @@ import type {
   BaseCustomFieldValue,
   Size,
   ThirdPartyDataDeclaration,
+  ThirdPartyDataDeclarationStatus,
 } from "../../common/types";
 import type { ConversionEvent_TrackingUrlsMapEntry } from "../creativeWrapper/creativeWrapper.type";
 import type {
@@ -980,22 +981,22 @@ export type BaseCreativeTemplateVariableValue = {
    */
   attributes: {
     "xsi:type":
-      | "AssetCreativeTemplateVariableValue"
-      | "LongCreativeTemplateVariableValue"
-      | "StringCreativeTemplateVariableValue"
-      | "ListStringCreativeTemplateVariableValue"
-      | "UrlCreativeTemplateVariableValue";
+    | "AssetCreativeTemplateVariableValue"
+    | "LongCreativeTemplateVariableValue"
+    | "StringCreativeTemplateVariableValue"
+    | "ListStringCreativeTemplateVariableValue"
+    | "UrlCreativeTemplateVariableValue";
   };
   /**
    * A uniqueName of the CreativeTemplateVariable.
    */
   uniqueName: string;
 } & (
-  | AssetCreativeTemplateVariableValue
-  | LongCreativeTemplateVariableValue
-  | StringCreativeTemplateVariableValue
-  | UrlCreativeTemplateVariableValue
-);
+    | AssetCreativeTemplateVariableValue
+    | LongCreativeTemplateVariableValue
+    | StringCreativeTemplateVariableValue
+    | UrlCreativeTemplateVariableValue
+  );
 
 /**
  * A Creative that is created by the specified creative template.
@@ -1215,6 +1216,13 @@ export type Creative = {
    * This is distinct from any associated companies that Google may detect programmatically.
    */
   thirdPartyDataDeclaration: ThirdPartyDataDeclaration;
+
+  /**
+   * The status of the ThirdPartyDataDeclaration associated with a given creative.
+   *
+   * This is calculated by comparing the companies detected via automated scanning/parsing, with the companies declared in the ThirdPartyDataDeclaration.
+   */
+  thirdPartyDataDeclarationStatus: ThirdPartyDataDeclarationStatus;
 } & BaseDynamicAllocationCreative &
   BaseRichMediaStudioCreative &
   ClickTrackingCreative &

--- a/lib/client/services/creative/creative.type.ts
+++ b/lib/client/services/creative/creative.type.ts
@@ -981,22 +981,22 @@ export type BaseCreativeTemplateVariableValue = {
    */
   attributes: {
     "xsi:type":
-    | "AssetCreativeTemplateVariableValue"
-    | "LongCreativeTemplateVariableValue"
-    | "StringCreativeTemplateVariableValue"
-    | "ListStringCreativeTemplateVariableValue"
-    | "UrlCreativeTemplateVariableValue";
+      | "AssetCreativeTemplateVariableValue"
+      | "LongCreativeTemplateVariableValue"
+      | "StringCreativeTemplateVariableValue"
+      | "ListStringCreativeTemplateVariableValue"
+      | "UrlCreativeTemplateVariableValue";
   };
   /**
    * A uniqueName of the CreativeTemplateVariable.
    */
   uniqueName: string;
 } & (
-    | AssetCreativeTemplateVariableValue
-    | LongCreativeTemplateVariableValue
-    | StringCreativeTemplateVariableValue
-    | UrlCreativeTemplateVariableValue
-  );
+  | AssetCreativeTemplateVariableValue
+  | LongCreativeTemplateVariableValue
+  | StringCreativeTemplateVariableValue
+  | UrlCreativeTemplateVariableValue
+);
 
 /**
  * A Creative that is created by the specified creative template.

--- a/lib/client/services/creativeWrapper/creativeWrapper.type.ts
+++ b/lib/client/services/creativeWrapper/creativeWrapper.type.ts
@@ -1,5 +1,5 @@
 import type { PageResult } from "../../../common/types";
-import type { ThirdPartyDataDeclaration, ThirdPartyDataDeclarationStatus } from "../../common/types";
+import type { ThirdPartyDataDeclaration } from "../../common/types";
 import type {
   ConversionEvent,
   CreativeWrapperOrdering,
@@ -78,13 +78,6 @@ export type CreativeWrapper = {
    * It is copied to one of the underlying creatives. If the header creative is active then it is persisted there. Otherwise it is stored on the footer creative.
    */
   thirdPartyDataDeclaration: ThirdPartyDataDeclaration;
-
-  /**
-   * The status of the ThirdPartyDataDeclaration associated with a given creative.
-   *
-   * This is calculated by comparing the companies detected via automated scanning/parsing, with the companies declared in the ThirdPartyDataDeclaration.
-   */
-  thirdPartyDataDeclarationStatus: ThirdPartyDataDeclarationStatus;
 
   /**
    * If there are multiple wrappers for a creative, then ordering defines the order in which the HTML snippets are rendered.

--- a/lib/client/services/creativeWrapper/creativeWrapper.type.ts
+++ b/lib/client/services/creativeWrapper/creativeWrapper.type.ts
@@ -1,5 +1,5 @@
 import type { PageResult } from "../../../common/types";
-import type { ThirdPartyDataDeclaration } from "../../common/types";
+import type { ThirdPartyDataDeclaration, ThirdPartyDataDeclarationStatus } from "../../common/types";
 import type {
   ConversionEvent,
   CreativeWrapperOrdering,
@@ -78,6 +78,13 @@ export type CreativeWrapper = {
    * It is copied to one of the underlying creatives. If the header creative is active then it is persisted there. Otherwise it is stored on the footer creative.
    */
   thirdPartyDataDeclaration: ThirdPartyDataDeclaration;
+
+  /**
+   * The status of the ThirdPartyDataDeclaration associated with a given creative.
+   *
+   * This is calculated by comparing the companies detected via automated scanning/parsing, with the companies declared in the ThirdPartyDataDeclaration.
+   */
+  thirdPartyDataDeclarationStatus: ThirdPartyDataDeclarationStatus;
 
   /**
    * If there are multiple wrappers for a creative, then ordering defines the order in which the HTML snippets are rendered.

--- a/lib/client/services/proposalLineItem/proposalLineItem.type.ts
+++ b/lib/client/services/proposalLineItem/proposalLineItem.type.ts
@@ -309,6 +309,10 @@ export type ProposalLineItem = {
    * The reason for pausing the ProposalLineItem, provided by the pauseRole. It is null when the ProposalLineItem is not paused. This attribute is read-only.
    */
   pauseReason: string;
+  /**
+   * The AllocationDeliveryProfile ID for this proposal line item.
+   */
+  deliveryAllocationProfileId?: number;
 };
 
 /**

--- a/lib/common/constants/index.ts
+++ b/lib/common/constants/index.ts
@@ -4,4 +4,4 @@ export { SERVICE_MAP };
 
 export const SCOPE = "https://www.googleapis.com/auth/dfp";
 export const DEFAULT_APPLICATION_NAME = "applicationName";
-export const DEFAULT_API_VERSION = "v202508";
+export const DEFAULT_API_VERSION = "v202605";


### PR DESCRIPTION
## What does this change?

- Adds new fields from [v202511 of the GAM SOAP API](https://developers.google.com/ad-manager/api/rel_notes#v202511)
  - Creatives: Added [ThirdPartyDataDeclarationStatus](https://developers.google.com/ad-manager/api/reference/v202511/CreativeService.ThirdPartyDataDeclarationStatus)
  - Line Items: Added [PublisherProvidedSignalsTargeting](https://developers.google.com/ad-manager/api/reference/v202511/LineItemService.PublisherProvidedSignalsTargeting)
  - Companies: Added [verifiedExchangeAdvertiserdId](https://developers.google.com/ad-manager/api/reference/v202511/CompanyService.Company#verifiedExchangeAdvertiserdId)

- Removes redundant field `settings` from `Company` type

- Adds new field from [v202602 of the GAM SOAP API](https://developers.google.com/ad-manager/api/rel_notes#v202602) 
  - LineItemSummary: [deliveryAllocationProfileId](https://developers.google.com/ad-manager/api/reference/v202602/ForecastService.LineItemSummary#deliveryAllocationProfileId)
  - ProposalLineItem: [deliveryAllocationProfileId](https://developers.google.com/ad-manager/api/reference/v202602/ForecastService.ProposalLineItem#deliveryAllocationProfileId) 

- Switches the default version of the GAM API to v202605 (the latest version available at the time)

_n.b. does not update any error types as these have not been reflected in this repo so are beyond the scope of this PR_

## Why

v202508 of the SOAP API [is being sunset](https://developers.google.com/ad-manager/api/deprecation) very soon